### PR TITLE
docs: fix NodePort→ingress, kind→k3d, site metadata (1.3.0 audit)

### DIFF
--- a/docs/3-codespaces.md
+++ b/docs/3-codespaces.md
@@ -19,7 +19,7 @@ Click to open Codespaces for this lab repository:
         - select any region, preferably one closest to your Dynatrace tenant
 
 ### Wait for Codespace
-We know your time is very valuable. This codespace takes around 7-10 minutes to be fully operational. A local Kubernetes ([kind](https://kind.sigs.k8s.io/){target="_blank"}) cluster will be configured and in it a sample application, AstroShop, will be deployed. To make your experience better, we are also installing and configuring tools like:
+We know your time is very valuable. This codespace takes around 7-10 minutes to be fully operational. A local Kubernetes ([k3d](https://k3d.io/){target="_blank"}) cluster will be configured and in it a sample application, AstroShop, will be deployed. To make your experience better, we are also installing and configuring tools like:
 
 **k9s kubectl helm node jq python3 gh**
 
@@ -27,7 +27,7 @@ We know your time is very valuable. This codespace takes around 7-10 minutes to 
 
 Your Codespace has now deployed the following resources:
 
-- A local Kubernetes ([kind](https://kind.sigs.k8s.io/){target="_blank"}) cluster, with some pre-deployed apps that will be used later in the demo.
+- A local Kubernetes ([k3d](https://k3d.io/){target="_blank"}) cluster, with some pre-deployed apps that will be used later in the demo.
 
 - CronJobs running in Kubernetes that generate some sample log data
 
@@ -82,7 +82,7 @@ kubectl get events -n default
 ```
 
 ### App exposure
-The Astroshop application is exposed via NodePort and it's mapping port 8080 to Cluster port 30100.
+The Astroshop application is accessible via the nginx ingress controller. The URL is shown in the greeting — run `printGreeting` to display it.
 
 Verify service:
 ```sh

--- a/docs/6-analyze-logs.md
+++ b/docs/6-analyze-logs.md
@@ -5,11 +5,9 @@
 
 The `astroshop` demo provides several feature flags that you can use to simulate different scenarios. These flags are managed by flagd, a simple feature flag service that supports OpenFeature.
 
-Flag values can be changed through the user interface provided at http://localhost:30100/feature when running the demo. Changing the values through this user interface will be reflected in the flagd service.
+Flag values can be changed through the feature flag UI — open the Astroshop URL from the greeting (`printGreeting`) and append `/feature`. Changing the values through this user interface will be reflected in the flagd service.
 
-Navigate to the feature flag user interface by adding `/feature` to the end of your Codespaces instance URL.
-
-For example: `https://super-duper-capybara-4wvj9xx7wpjh76qr-30100.app.github.dev/feature`
+Navigate to the feature flag UI by adding `/feature` to the end of your app URL. In GitHub Codespaces, the URL will look similar to `https://your-codespace-name-80.app.github.dev/feature`.
 
 Locate the flag **paymentFailure**.  Click the drop down box and change it from `off` to a percentage, in this case we are choosing `50%`.  Click `save` at the top of the page.  The feature flag should start working within a minute.
 


### PR DESCRIPTION
## Summary

- Replace NodePort port exposure references with nginx ingress / `printGreeting` pattern
- Update Kubernetes cluster description from `kind` to `k3d`
- Fix `site_name` and `repo_url` in `mkdocs.yaml` (copy-paste from template, never updated)
- Remove `scratch.md` debug file (live-debugger only)
- Fix stale `codespaces-synchronizer` reference → `codespaces-framework` (bizobs only)

Part of the post-1.3.0 documentation audit.

## Test plan
- [ ] Verify MkDocs site builds and renders correct `site_name` in browser title
- [ ] Verify "View Code on GitHub" link points to the correct repo
- [ ] Verify app URLs reference `printGreeting` instead of hardcoded ports