### PR TITLE
chore: sync framework @ v1.3.1

### DIFF
--- a/.devcontainer/util/source_framework.sh
+++ b/.devcontainer/util/source_framework.sh
@@ -13,7 +13,7 @@
 #                    Local to the container -> fast access, lost on container rebuild
 
 # Framework version pin — sync push-update updates this line
-FRAMEWORK_VERSION="${FRAMEWORK_VERSION:-1.3.0}"
+FRAMEWORK_VERSION="${FRAMEWORK_VERSION:-v1.3.1}"
 
 REPO_PATH="$(pwd)"
 RepositoryName="$(basename "$REPO_PATH")"

--- a/.github/workflows/deploy-ghpages.yaml
+++ b/.github/workflows/deploy-ghpages.yaml
@@ -17,14 +17,16 @@ jobs:
     - uses: actions/setup-python@v2
       with:
         python-version: '3.x'
-    - name: Fetch framework mkdocs-base.yaml
+    - name: Fetch framework assets (mkdocs-base + theme)
       run: |
         FRAMEWORK_VERSION=$(grep -oP ':-\K[^}"]+' .devcontainer/util/source_framework.sh | head -1)
         echo "Using framework version: $FRAMEWORK_VERSION"
         curl -fsSL "https://raw.githubusercontent.com/dynatrace-wwse/codespaces-framework/${FRAMEWORK_VERSION}/mkdocs-base.yaml" -o mkdocs-base.yaml
+        mkdir -p docs/stylesheets
+        curl -fsSL "https://raw.githubusercontent.com/dynatrace-wwse/codespaces-framework/${FRAMEWORK_VERSION}/docs/stylesheets/extra.css" -o docs/stylesheets/extra.css
     - name: MKDocs - install requirements, build, gh-deploy
       run: |
         pip install --break-system-packages -r docs/requirements/requirements-mkdocs.txt
-        git fetch origin gh-pages:gh-pages
+        git fetch origin gh-pages:gh-pages 2>/dev/null || true
         mkdocs build
-        mkdocs gh-deploy
+        mkdocs gh-deploy --force

--- a/.gitignore
+++ b/.gitignore
@@ -219,3 +219,6 @@ mkdocs-base.yaml
 
 # Temporary Dockerfile from cache for local builds
 Dockerfile.framework
+
+
+docs/stylesheets/extra.css


### PR DESCRIPTION
## Sync update

- Bumps `FRAMEWORK_VERSION` from `1.3.0` to `v1.3.1`.
- Updates templates (`source_framework.sh`, `Makefile`).
- Removes framework-owned files (Category A) — now pulled from cache.

Auto-generated by `sync push-update`.