### PR TITLE
docs: remove per-page JS RUM snippets, update main.html for auto page tracking

### DIFF
--- a/docs/2-getting-started.md
+++ b/docs/2-getting-started.md
@@ -1,4 +1,3 @@
---8<-- "snippets/send-bizevent/2-getting-started.js"
 --8<-- "snippets/requirements.md"
 
 ## Prerequisites

--- a/docs/3-codespaces.md
+++ b/docs/3-codespaces.md
@@ -1,4 +1,3 @@
---8<-- "snippets/send-bizevent/3-codespaces.js"
 
 --8<-- "snippets/dt-enablement.md"
 

--- a/docs/4-deploy-dynatrace.md
+++ b/docs/4-deploy-dynatrace.md
@@ -1,5 +1,4 @@
 # Deploy Dynatrace
---8<-- "snippets/send-bizevent/4-deploy-dynatrace.js"
 
 Dynatrace provides integrated log management and analytics for your Kubernetes environments by either running the OneAgent Log Module or integrating with log collectors such as Fluent Bit, OpenTelemetry Collector, Logstash, or Fluentd.
 

--- a/docs/5-configure-dynatrace.md
+++ b/docs/5-configure-dynatrace.md
@@ -1,5 +1,4 @@
 # Configure Dynatrace
---8<-- "snippets/send-bizevent/5-configure-dynatrace.js"
 
 You can configure log ingestion rules in Dynatrace to control which logs should be collected from your Kubernetes environment. The rules leverage Kubernetes metadata and other common log entry attributes to determine which logs are to be ingested. The standard log processing features from OneAgent, including sensitive data masking, timestamp configuration, log boundary definition, and automatic enrichment of log records, are also available for Kubernetes logs.
 

--- a/docs/6-analyze-logs.md
+++ b/docs/6-analyze-logs.md
@@ -1,5 +1,4 @@
 # Analyze Logs
---8<-- "snippets/send-bizevent/6-analyze-logs.js"
 
 ## Enable Astroshop Problem Patterns
 

--- a/docs/cleanup.md
+++ b/docs/cleanup.md
@@ -1,4 +1,3 @@
---8<-- "snippets/send-bizevent/cleanup.js"
 
 --8<-- "snippets/feedback.md"
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,4 +1,3 @@
---8<-- "snippets/send-bizevent/index.js"
 
 --8<-- "snippets/disclaimer.md"
 

--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -8,3 +8,16 @@
     crossorigin="anonymous"></script>
   {% endif %}
 {% endblock %}
+
+{% block scripts %}
+  {{ super() }}
+  {% if config.extra.rum_snippet and page is defined and page.title %}
+  <script>
+    document.addEventListener('DOMContentLoaded', function() {
+      if (typeof dynatrace !== 'undefined') {
+        dynatrace.sendBizEvent('page_load', {'page': {{ page.title | tojson }}});
+      }
+    });
+  </script>
+  {% endif %}
+{% endblock %}

--- a/docs/snippets/resources.js
+++ b/docs/snippets/resources.js
@@ -1,5 +1,0 @@
-<script>
-document.addEventListener('DOMContentLoaded', function() {
-  dynatrace.sendBizEvent('page_load', {"page": "6. Resources"});
-});
-</script>

--- a/docs/snippets/send-bizevent/2-getting-started.js
+++ b/docs/snippets/send-bizevent/2-getting-started.js
@@ -1,5 +1,0 @@
-<script>
-document.addEventListener('DOMContentLoaded', function() {
-  dynatrace.sendBizEvent('page_load', {"page": "2. Getting started"})
-});
-</script>

--- a/docs/snippets/send-bizevent/3-codespaces.js
+++ b/docs/snippets/send-bizevent/3-codespaces.js
@@ -1,5 +1,0 @@
-<script>
-document.addEventListener('DOMContentLoaded', function() {
-  dynatrace.sendBizEvent('page_load', {"page": "3. Codespaces"})
-});
-</script>

--- a/docs/snippets/send-bizevent/4-deploy-dynatrace.js
+++ b/docs/snippets/send-bizevent/4-deploy-dynatrace.js
@@ -1,5 +1,0 @@
-<script>
-document.addEventListener('DOMContentLoaded', function() {
-  dynatrace.sendBizEvent('page_load', {"page": "4. Deploy Dynatrace"})
-});
-</script>

--- a/docs/snippets/send-bizevent/5-configure-dynatrace.js
+++ b/docs/snippets/send-bizevent/5-configure-dynatrace.js
@@ -1,5 +1,0 @@
-<script>
-document.addEventListener('DOMContentLoaded', function() {
-  dynatrace.sendBizEvent('page_load', {"page": "5. Configure Dynatrace"})
-});
-</script>

--- a/docs/snippets/send-bizevent/6-analyze-logs.js
+++ b/docs/snippets/send-bizevent/6-analyze-logs.js
@@ -1,5 +1,0 @@
-<script>
-document.addEventListener('DOMContentLoaded', function() {
-  dynatrace.sendBizEvent('page_load', {"page": "6. Analyze Logs"})
-});
-</script>

--- a/docs/snippets/send-bizevent/cleanup.js
+++ b/docs/snippets/send-bizevent/cleanup.js
@@ -1,5 +1,0 @@
-<script>
-document.addEventListener('DOMContentLoaded', function() {
-  dynatrace.sendBizEvent('page_load', {"page": "7. Cleanup"})
-});
-</script>

--- a/docs/snippets/send-bizevent/index.js
+++ b/docs/snippets/send-bizevent/index.js
@@ -1,5 +1,0 @@
-<script>
-document.addEventListener('DOMContentLoaded', function() {
-  dynatrace.sendBizEvent('page_load', {"page": "1. About"})
-});
-</script>

--- a/docs/snippets/whats-next.js
+++ b/docs/snippets/whats-next.js
@@ -1,5 +1,0 @@
-<script>
-document.addEventListener('DOMContentLoaded', function() {
-  dynatrace.sendBizEvent('page_load', {"page": "7. What's next?"});
-});
-</script>


### PR DESCRIPTION
## Summary

- Removes all `docs/snippets/*.js` files (per-page RUM bizEvent scripts)
- Removes `--8<-- "snippets/*.js"` includes from all markdown pages
- Updates `docs/overrides/main.html` to the framework v1.3.0 template

## Why

Page tracking via BizEvents is now handled centrally by `docs/overrides/main.html`, which:
1. Loads the RUM agent from `extra.rum_snippet` in `mkdocs.yaml`
2. Fires a `page_load` BizEvent on every page using the page title from the `nav` definition

Per-page JS snippet files were redundant and required manual maintenance for each new page.

## Test plan
- [ ] Verify docs build succeeds in CI
- [ ] Confirm no broken snippet includes remain in markdown files

🤖 Generated with [Claude Code](https://claude.com/claude-code)