### PR TITLE
Add Dynatrace App badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 # <img src="https://cdn.bfldr.com/B686QPH3/at/w5hnjzb32k5wcrcxnwcx4ckg/Dynatrace_signet_RGB_HTML.svg?auto=webp&format=pngg" alt="DT logo" width="30">  Enablement Dynatrace Log Ingest 101
 
 [![Dynatrace](https://img.shields.io/badge/Dynatrace-Intelligence-purple?logo=dynatrace&logoColor=white)](https://dynatrace-wwse.github.io/codespaces-framework/dynatrace-integration/#mcp-server-integration)
+[![Dynatrace App](https://img.shields.io/badge/Dynatrace_App-Optimized-1496FF?logo=dynatrace&logoColor=white)](https://dynatrace-wwse.github.io)
 [![Mastering](https://img.shields.io/badge/Mastering-Complexity-8A2BE2?logo=dynatrace)](https://dynatrace-wwse.github.io)
 [![Downloads](https://img.shields.io/docker/pulls/shinojosa/dt-enablement?logo=docker)](https://hub.docker.com/r/shinojosa/dt-enablement)
 [![Integration tests](https://github.com/dynatrace-wwse/enablement-dynatrace-log-ingest-101/actions/workflows/integration-tests.yaml/badge.svg)](https://github.com/dynatrace-wwse/enablement-dynatrace-log-ingest-101/actions)


### PR DESCRIPTION
Adds a **Dynatrace App — Optimized** badge to the README badge row, marking this lab as optimized for the Dynatrace Enablement App. Pairs with the `dynatrace-app` hub tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)