### PR TITLE
Fix DynaKube shell-verification operator (gte -> gt); gate was silently dropped

### DIFF
--- a/docs/4-deploy-dynatrace.md
+++ b/docs/4-deploy-dynatrace.md
@@ -168,8 +168,8 @@ question: "Verify the two DynaKube objects were created in the dynatrace namespa
 buttonText: "Check DynaKube"
 command: "kubectl get dynakube -n dynatrace --no-headers 2>/dev/null | grep -c ''"
 expect:
-  operator: gte
-  value: 2
+  operator: gt
+  value: 1
 hint: "Run `kubectl apply -f dynakube.yaml` in the Terminal tab. The lab uses two DynaKubes: one for Kubernetes monitoring + Log Management, one for the agents (Application Observability)."
 explanation: "Both DynaKube objects exist — the Operator is reconciling Kubernetes monitoring, Application Observability, and the Log Module."
 -->


### PR DESCRIPTION
## Problem
`docs/4-deploy-dynatrace.md` "Check DynaKube" shell-verification used `expect.operator: gte`. `gte` is a **DQL** operator; valid **shell** operators are `exit-zero | contains | not-empty | gt` (`VALID_SHELL_OPERATORS` in `dynatrace-app-enablements/api/import-lab.function.ts`). The importer therefore **skips the question**, so the gate never renders in the Enablement App.

## Fix
`operator: gt`, `value: 1`. For an integer count, `> 1` is equivalent to the intended `>= 2` (both DynaKube objects present). Command and intent unchanged.

## How it was found
The new app-layer **lab-content contract test** in `dynatrace-app-enablements` (`ui/app/training/utils/__tests__/labContent.contract.test.ts`) lints real lab markdown and flagged this as the only invalid shell operator across the labs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)